### PR TITLE
fix(install script): Replace wildcard with package name

### DIFF
--- a/scripts/prepare_ubuntu_pluto
+++ b/scripts/prepare_ubuntu_pluto
@@ -6,7 +6,7 @@ echo "installing standard libraries ...please wait..."
 sudo apt-get -qq update
 sudo apt-get -y install build-essential libxml2-dev bison flex libcdk5-dev cmake libaio-dev libusb-1.0-0-dev libserialport-dev libavahi-client-dev
 sudo apt-get -y install libasound2-dev libfftw3-dev sndfile-tools libsndfile1-dev git libad9361-dev
-sudo apt-get -y install autotools-dev automake pavucontrol gpiod libgpiod-dev libpuls*
+sudo apt-get -y install autotools-dev automake pavucontrol gpiod libgpiod-dev libpulse-dev
 
 # install newest mono version (mono from standard repositories is always too old)
 echo "mono (.NET): install latest version"


### PR DESCRIPTION
Replaces the wildcard in the dependency installation with the proper package name, as this leads to package conflicts on some systems.

```
 libpulse-ocaml : Conflicts: libpulse-ocaml:armhf but 0.1.3-1+b1 is to be installed
 libpulse-ocaml:armhf : Depends: ocaml-base-nox-4.11.1:armhf
                        Conflicts: libpulse-ocaml but 0.1.3-1+b1 is to be installed
 libpulse-ocaml-dev : Conflicts: libpulse-ocaml-dev:armhf but 0.1.3-1+b1 is to be installed
 libpulse-ocaml-dev:armhf : Depends: ocaml-nox-4.11.1:armhf
                            Depends: ocaml-findlib:armhf but it is not installable
                            Conflicts: libpulse-ocaml-dev but 0.1.3-1+b1 is to be installed
```
System: Raspberry PI4 8GB - Raspbian 11.6                    